### PR TITLE
Latest CAK7 changes: thx aracek and fam.trichter (2020-1)

### DIFF
--- a/cardlist.c
+++ b/cardlist.c
@@ -55,6 +55,7 @@ static uint8_t key3588[136] = {0x0};
 static uint8_t data50[80] = {0x0};
 static uint8_t mod50[80] = {0x0};
 static uint8_t nuid[4] = {0x0};
+static uint8_t idird[4] = {0x0};
 static uint8_t cwpk[16] = {0x0};
 /* Max TV */
 static uint8_t maxtv_mod1[112] = {0x0};
@@ -63,6 +64,7 @@ static uint8_t maxtv_key3588[136] = {0x0};
 static uint8_t maxtv_data50[80] = {0x0};
 static uint8_t maxtv_mod50[80] = {0x0};
 static uint8_t maxtv_nuid[4] = {0x0};
+static uint8_t maxtv_idird[4] = {0x0};
 static uint8_t maxtv_cwpk[16] = {0x0};
 #endif
 
@@ -372,10 +374,12 @@ void findatr(struct s_reader *reader) {
 			reader->mod50_length = sizeof(mod50);
 			memcpy(reader->nuid, nuid, sizeof(nuid));
 			reader->nuid_length = sizeof(nuid);
+			memcpy(reader->idird, idird, sizeof(idird));
+			reader->idird_length = sizeof(idird);
 			memcpy(reader->cwekey0, cwpk, sizeof(cwpk));
 			reader->cwekey0_length = sizeof(cwpk);
 		} else {
-			rdr_log(reader, "no keys built in, use config values mod1 + mod2 + key3588 + data50 + mod50 + nuid + cwekey0");
+			rdr_log(reader, "no keys built in, use config values mod1 + mod2 + key3588 + data50 + mod50 + nuid + idird + cwekey0");
 		}
 		reader->cak7_mode = 1;
 		reader->forceemmg = 1;
@@ -400,10 +404,12 @@ void findatr(struct s_reader *reader) {
 			reader->mod50_length = sizeof(maxtv_mod50);
 			memcpy(reader->nuid, maxtv_nuid, sizeof(maxtv_nuid));
 			reader->nuid_length = sizeof(maxtv_nuid);
+			memcpy(reader->idird, maxtv_idird, sizeof(maxtv_idird));
+			reader->idird_length = sizeof(maxtv_idird);
 			memcpy(reader->cwekey0, maxtv_cwpk, sizeof(maxtv_cwpk));
 			reader->cwekey0_length = sizeof(maxtv_cwpk);
 		} else {
-			rdr_log(reader, "no keys built in, use config values mod1 + mod2 + key3588 + data50 + mod50 + nuid + cwekey0");
+			rdr_log(reader, "no keys built in, use config values mod1 + mod2 + key3588 + data50 + mod50 + nuid + idird + cwekey0");
 		}
 		reader->blockemm = (8 | reader->blockemm);
 #else

--- a/csctapi/io_serial.c
+++ b/csctapi/io_serial.c
@@ -490,10 +490,7 @@ bool IO_Serial_Write(struct s_reader *reader, uint32_t delay, uint32_t timeout, 
 {
 	const struct s_cardreader *crdr_ops = reader->crdr;
 	if (!crdr_ops) return ERROR;
-	if(reader->wdelay)
-	{
-		delay = reader->wdelay;
-	}
+
 	if(timeout == 0)   // General fix for readers not communicating timeout and delay
 	{
 		if(reader->char_delay != 0) { timeout = reader->char_delay; }

--- a/globals.h
+++ b/globals.h
@@ -1481,7 +1481,6 @@ struct s_reader										// contains device info, reader info and card info
 	uint8_t			keepalive;
 	uint8_t			changes_since_shareupdate;
 	int32_t			resetcycle;						// ECM until reset
-	int32_t			wdelay;						// ECM until reset
 	int32_t			resetcounter;					// actual count
 	uint32_t		auprovid;						// AU only for this provid
 	int8_t			audisabled;						// exclude reader from auto AU
@@ -1583,9 +1582,10 @@ struct s_reader										// contains device info, reader info and card info
 	uint8_t			cak7_camstate;
 	uint8_t			cak7_aes_key[32];
 	uint8_t			cak7_aes_iv[16];
-	uint8_t			forcecwswap;
-	uint8_t			evensa;
-	uint8_t			forceemmg;
+	int8_t			forcecwswap;
+	int8_t			evensa;
+	int8_t			forceemmg;
+	int8_t                  cwpkota;
 
 #endif
 #ifdef CS_CACHEEX
@@ -1611,7 +1611,7 @@ struct s_reader										// contains device info, reader info and card info
 	int32_t			l_port;
 	CAIDTAB			ctab;
 	uint32_t		boxid;
-	uint8_t			cak7_mode;
+	int8_t			cak7_mode;
 	uint8_t			cak7type;
 	uint8_t			cwpkcaid[2];
 	uint8_t			cwpkcaid_length;

--- a/module-webif.c
+++ b/module-webif.c
@@ -2254,8 +2254,6 @@ static char *send_oscam_reader_config(struct templatevars *vars, struct uriparam
 	// Reset Cycle
 	tpl_printf(vars, TPLADD, "RESETCYCLE", "%d", rdr->resetcycle);
 
-	tpl_printf(vars, TPLADD, "WDELAY", "%d", rdr->wdelay);
-
 	// Disable Serverfilter
 	if(!apicall)
 	{
@@ -2643,6 +2641,10 @@ static char *send_oscam_reader_config(struct templatevars *vars, struct uriparam
 	// force_EMM_82
 	if(rdr->forceemmg)
 		{ tpl_addVar(vars, TPLADD, "FORCEEMMGCHECKED", "checked"); }
+
+        // OTA_CWPKs
+        if(rdr->cwpkota)
+                { tpl_addVar(vars, TPLADD, "CWPKOTACHECKED", "checked"); }
 #endif
 
 	// CWPK CaID (CAK7)

--- a/oscam-config-reader.c
+++ b/oscam-config-reader.c
@@ -1746,7 +1746,6 @@ static const struct config_list reader_opts[] =
 	DEF_OPT_INT32("reconnecttimeout"              , OFS(tcp_rto),                         DEFAULT_TCP_RECONNECT_TIMEOUT),
 	DEF_OPT_INT32("reconnectdelay"                , OFS(tcp_reconnect_delay),             60000),
 	DEF_OPT_INT32("resetcycle"                    , OFS(resetcycle),                      0),
-	DEF_OPT_INT32("wdelay"                        , OFS(wdelay),                          0),
 	DEF_OPT_INT8("disableserverfilter"            , OFS(ncd_disable_server_filt),         0),
 	DEF_OPT_INT8("connectoninit"                  , OFS(ncd_connect_on_init),             0),
 	DEF_OPT_UINT8("keepalive"                     , OFS(keepalive),                       0),
@@ -1807,6 +1806,7 @@ static const struct config_list reader_opts[] =
 	DEF_OPT_INT8("forcecwswap"                    , OFS(forcecwswap),                     0),
 	DEF_OPT_INT8("evensa"                         , OFS(evensa),                          0),
 	DEF_OPT_INT8("forceemmg"                      , OFS(forceemmg),                       0),
+	DEF_OPT_INT8("cwpkota"                        , OFS(cwpkota),                         0),
 #endif
 
 	DEF_OPT_INT8("cak7_mode"                      , OFS(cak7_mode),                       0),
@@ -1919,7 +1919,7 @@ static bool reader_check_setting(const struct config_list *UNUSED(clist), void *
 	// These are written only when the reader is physical reader
 	static const char *hw_only_settings[] =
 	{
-		"readnano", "resetcycle", "wdelay", "smargopatch", "autospeed", "sc8in1_dtrrts_patch", "boxid","fix07",
+		"readnano", "resetcycle", "smargopatch", "autospeed", "sc8in1_dtrrts_patch", "boxid","fix07",
 		"fix9993", "rsakey", "deskey", "ins7e", "ins7e11", "ins2e06", "k1_generic", "k1_unique", "force_irdeto", "needsemmfirst", "boxkey",
 		"atr", "detect", "nagra_read", "mhz", "cardmhz", "readtiers", "read_old_classes", "use_gpio", "needsglobalfirst",
 #ifdef READER_NAGRA_MERLIN

--- a/webif/readerconfig/readerconfig_hwreader.html
+++ b/webif/readerconfig/readerconfig_hwreader.html
@@ -17,7 +17,6 @@
 ##TPLREADERPINCODE##
 ##TPLREADERCONFIGNANO##
 				<TR><TD><A>Reset after No. ECM:</A></TD><TD><input name="resetcycle" class="short" type="text" maxlength="5" value="##RESETCYCLE##"></TD></TR>
-				<TR><TD><A>Write Delay:</A></TD><TD><input name="wdelay" class="short" type="text" maxlength="5" value="##WDELAY##"></TD></TR>
 				<TR><TD><A>Deprecated:</A></TD><TD><input name="deprecated" type="hidden" value="0"><input name="deprecated" type="checkbox" value="1" ##DEPRECATEDCHECKED##><label></label></TD></TR>
 ##TPLREADERCONFIGCRYPTOWORKS##
 ##TPLREADERCONFIGNAGRA##

--- a/webif/readerconfig/readerconfig_hwreader_nagracak7.html
+++ b/webif/readerconfig/readerconfig_hwreader_nagracak7.html
@@ -10,13 +10,14 @@
 				<TR><TD><A>key3310:</A></TD><TD><textarea name="key3310" rows="1" class="bt" maxlength="32">##KEY3310##</textarea></TD></TR>
 				<TR><TD><A>data50:</A></TD><TD><textarea name="data50" rows="4" class="bt" maxlength="160">##DATA50##</textarea></TD></TR>
 				<TR><TD><A>mod50:</A></TD><TD><textarea name="mod50" rows="4" class="bt" maxlength="160">##MOD50##</textarea></TD></TR>
-				<TR><TD><A>Idird:</A></TD><TD><input name="idird" class="medium" type="text" maxlength="8" value="##IDIRD##"></TD></TR>
+				<TR><TD><A>idird:</A></TD><TD><input name="idird" class="medium" type="text" maxlength="8" value="##IDIRD##"></TD></TR>
 				<TR><TD><A>CMD0E ProvID:</A></TD><TD><input name="cmd0eprov" class="medium" type="text" maxlength="4" value="##CMD0EPROV##"> use only if CMD0E needs ProvID other than sysid</TD></TR>
 				<TR><TD><A>Nuid:</A></TD><TD><input name="nuid" class="medium" type="text" maxlength="8" value="##NUID##"></TD></TR>
-				<TR><TD><A>Force Pairing (1 byte):</A></TD><TD><input name="forcepair" class="medium" type="text" maxlength="2" value="##FORCEPAIR##"></TD></TR>
-				<TR><TD><A>OTP CSC Number of keys:</A></TD><TD><input name="otpcsc" class="medium" type="text" maxlength="4" value="##OTPCSC##"></TD></TR>
-				<TR><TD><A>OTA CSC Number of keys:</A></TD><TD><input name="otacsc" class="medium" type="text" maxlength="4" value="##OTACSC##"></TD></TR>
-				<TR><TD><A>CaID for CWPKs:</A></TD><TD><input name="cwpkcaid" class="medium" type="text" maxlength="4" value="##CWPKCAID##"></TD></TR>
+				<TR><TD><A>Force Pairing (00 - global):</A></TD><TD><input name="forcepair" class="medium" type="text" maxlength="2" value="##FORCEPAIR##"></TD></TR>
+				<TR><TD><A>Force OTP CSC (optional):</A></TD><TD><input name="otpcsc" class="medium" type="text" maxlength="4" value="##OTPCSC##"></TD></TR>
+				<TR><TD><A>Force OTA CSC (optional):</A></TD><TD><input name="otacsc" class="medium" type="text" maxlength="4" value="##OTACSC##"></TD></TR>
+				<TR><TD><A>CaID BoxEMM:</A></TD><TD><input name="cwpkcaid" class="medium" type="text" maxlength="4" value="##CWPKCAID##"></TD></TR>
+				<TR><TD><A>OTA (Over-The-Air) CWPK:</A></TD><TD><input name="cwpkota" type="hidden" value="0"><input name="cwpkota" type="checkbox" value="1" ##CWPKOTACHECKED##><label></label></TD></TR>
 				<TR><TD><A>CWPK0:</A></TD><TD><input name="cwekey0" class="longer" type="text" maxlength="32" value="##CWEKEY0##"></TD></TR>
 				<TR><TD><A>CWPK1:</A></TD><TD><input name="cwekey1" class="longer" type="text" maxlength="32" value="##CWEKEY1##"></TD></TR>
 				<TR><TD><A>CWPK2:</A></TD><TD><input name="cwekey2" class="longer" type="text" maxlength="32" value="##CWEKEY2##"></TD></TR>


### PR DESCRIPTION
- write delay (wdelay) has been removed
- otpcsc and otacsc are really optional now. if empty, oscam will calculate it automatically
- optimizing code to force card init into GLOBAL mode DT05_20
- new OTA (Over-The-Air) CWPK for Cayman
- idird configuration for HD0X and MaxTV