### PR TITLE
CAK7: Update ValidTo date if necessary

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -1585,6 +1585,7 @@ struct s_reader										// contains device info, reader info and card info
 	uint8_t			cak7_camstate;
 	uint8_t			cak7_aes_key[32];
 	uint8_t			cak7_aes_iv[16];
+	struct timeb	last_refresh;
 	int8_t			forcecwswap;
 	int8_t			evensa;
 	int8_t			forceemmg;

--- a/reader-nagracak7.c
+++ b/reader-nagracak7.c
@@ -1501,6 +1501,10 @@ static int32_t nagra3_card_info(struct s_reader *reader)
 	{
 		rdr_log(reader, "Prv.ID: %s", cs_hexdump(1, reader->prid[i], 4, tmp, sizeof(tmp)));
 	}
+	
+	struct timeb now;
+	cs_ftime(&now);
+	reader->last_refresh=now;
 
 	if(reader->cak7type != 3)
 	{
@@ -1845,6 +1849,16 @@ static int32_t nagra3_do_emm(struct s_reader *reader, EMM_PACKET *ep)
 				}
 			}
 		}
+
+		struct timeb now;
+		cs_ftime(&now);
+		int64_t gone_now = comp_timeb(&now, &reader->emm_last);
+		int64_t gone_refresh = comp_timeb(&reader->emm_last, &reader->last_refresh);
+		if((gone_now > 3600*1000) || (gone_refresh > 12*3600*1000))
+		{
+			add_job(reader->client, ACTION_READER_CARDINFO, NULL, 0); // refresh entitlement since it might have been changed!
+		}
+
 	}
 	return OK;
 }


### PR DESCRIPTION
Fixes not working update of the ValidTo date of CAK7 cards without manually restarting the reader or refreshing the entitlements (see if https://www.digital-eliteboard.com/threads/warum-aendert-sich-das-validto-datum-eine-hd03-04-05-immer-erst-nach-dem-neustart-des-readers.488369/post-3765162)